### PR TITLE
ci: fix sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Git user info
         run: |


### PR DESCRIPTION
Implements https://github.com/auxolotl/nixpkgs/issues/13#issuecomment-2094076640

closes https://github.com/auxolotl/nixpkgs/issues/13

To explain, `actions/checkout@4` defaults to a fetch depth of 1. This ment that it was not fetching any of the repos history, this ment that when trying to merge we were getting an error - "unrelated histories". So in order to fix that we need to set the fetch depth to 0 which fetches **all** history. 